### PR TITLE
Catch safari 'global code' and function name with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ function fromStackTraceProperty(stackString) { // new Opera
 }
 
 function fromStackProperty(stackString) {
-	var chrome = /^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
-		gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|http|https).*?):(\d+)(?::(\d+))?\s*$/i,
+	var chrome = /^\s*at (?:((?:\[object object\])?[\S ]*\S+(?: \[as \S+\])?) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
+		gecko = /^\s*(\S*[ \S]*)(?:\((.*?)\))?@((?:file|http|https).*?):(\d+)(?::(\d+))?\s*$/i,
 		lines = stackString.split('\n'),
 		stack = [],
 		parts;

--- a/test/test.js
+++ b/test/test.js
@@ -80,4 +80,24 @@ describe("stack-parser", function() {
 			{url: 'http://localhost:3000/stackgen.js', func: 'global code', args: '', line:  14, column: 5 }
 		]);
 	});
+
+	it("should parse stacks with function name containing spaces in gecko-style stacks", function() {
+		var stack = "my function@http://localhost:3000/stackgen.js:10:21";
+
+		var parsed = parse(stack);
+		parsed.should.have.lengthOf(1);
+		parsed.should.eql([
+			{url: 'http://localhost:3000/stackgen.js', func: 'my function', args: '', line:  10, column: 21 }
+		]);
+	});
+
+	it("should parse stacks with function name containing spaces in chrome-style stacks", function() {
+		var stack = "ReferenceError: nonExistantFunction is not defined\n    at my function (http://localhost:3000/stackgen.js:10:21)";
+
+		var parsed = parse(stack);
+		parsed.should.have.lengthOf(1);
+		parsed.should.eql([
+			{url: 'http://localhost:3000/stackgen.js', func: 'my function', line:  10, column: 21 }
+		]);
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -72,11 +72,12 @@ describe("stack-parser", function() {
 		var stack = "fn3@http://localhost:3000/stackgen.js:10:21\nfn2@http://localhost:3000/stackgen.js:6:5\nfn1@http://localhost:3000/stackgen.js:2:5\nglobal code@http://localhost:3000/stackgen.js:14:5";
 
 		var parsed = parse(stack);
-		parsed.should.have.lengthOf(3);
+		parsed.should.have.lengthOf(4);
 		parsed.should.eql([
 			{url: 'http://localhost:3000/stackgen.js', func: 'fn3', args: '', line: 10, column: 21 },
 			{url: 'http://localhost:3000/stackgen.js', func: 'fn2', args: '', line:  6, column: 5 },
-			{url: 'http://localhost:3000/stackgen.js', func: 'fn1', args: '', line:  2, column: 5 }
+			{url: 'http://localhost:3000/stackgen.js', func: 'fn1', args: '', line:  2, column: 5 },
+			{url: 'http://localhost:3000/stackgen.js', func: 'global code', args: '', line:  14, column: 5 }
 		]);
 	});
 });


### PR DESCRIPTION
The tests are passing, but some manual checking for some edge case I might not have think would probably be a good idea.
